### PR TITLE
fix: escape apostrophes

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,7 +3,7 @@ export default function About() {
     <div className="mx-auto max-w-5xl space-y-4 p-4">
       <h1 className="text-3xl font-bold text-[#FF0000]">About Us</h1>
       <p>
-        Mdl Professional Food Service LLC DBA Lee's Concessions began with a
+        Mdl Professional Food Service LLC DBA Lee&apos;s Concessions began with a
         passion for great food and community. Owner Mike Lee brings years of
         experience in food service and a commitment to professional, friendly
         hospitality.

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
     <footer className="bg-[#FFD700] text-[#FF0000]">
       <div className="mx-auto max-w-6xl p-4 text-center">
         <p className="font-bold">
-          Mdl Professional Food Service LLC DBA Lee's Concessions
+          Mdl Professional Food Service LLC DBA Lee&apos;s Concessions
         </p>
         <p>
           <a href="mailto:mlee2@woh.rr.com" className="underline">
@@ -21,7 +21,7 @@ export default function Footer() {
           </Link>
         </div>
         <p className="mt-2 text-sm">
-          &copy; {new Date().getFullYear()} Lee's Concessions. All rights reserved.
+          &copy; {new Date().getFullYear()} Lee&apos;s Concessions. All rights reserved.
         </p>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,12 +8,12 @@ export default function Header() {
         <Link href="/" className="flex items-center space-x-2">
           <Image
             src="/images/LeesLOGO.JPG"
-            alt="Lee's Concessions Logo"
+            alt="Lee&apos;s Concessions Logo"
             width={48}
             height={48}
             className="rounded"
           />
-          <span className="font-bold">Lee's Concessions</span>
+          <span className="font-bold">Lee&apos;s Concessions</span>
         </Link>
         <nav className="space-x-4 font-semibold">
           <Link href="/about" className="hover:text-[#FFD700]">


### PR DESCRIPTION
## Summary
- escape apostrophes in about page and shared components to satisfy ESLint

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font `Inter`)

------
https://chatgpt.com/codex/tasks/task_e_6899109e20e48327ac41d6e13f79d6ab