### PR TITLE
Use trailer image for site background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
 body {
-  @apply bg-white text-gray-900;
+  @apply text-gray-900;
+  background-image: url('/images/trailer.png');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
 }

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -15,10 +15,10 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
-        className={`${inter.variable} font-sans bg-white text-gray-900 flex min-h-screen flex-col`}
+        className={`${inter.variable} font-sans text-gray-900 flex min-h-screen flex-col`}
       >
         <Header />
-        <main className="flex-1">{children}</main>
+        <main className="flex-1 bg-white/80 backdrop-blur-sm">{children}</main>
         <Footer />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- apply food trailer image as site-wide background to reduce blank white areas
- wrap main content with translucent overlay for readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68991e05eb1c8327b2ec15010e12f50f