### PR TITLE
Use existing images for product cards

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -84,13 +84,15 @@ export default function Home() {
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <ProductCard
             title="Box Lunch"
-            image="/images/tenderloin.png"
+            imageSrc="/images/tenderloin.png"
+            imageAlt="Breaded tenderloin sandwich"
             description="Perfect individual meals for any gathering."
             price="$12"
           />
           <ProductCard
             title="Party Tray"
-            image="/images/pretzel.png"
+            imageSrc="/images/pretzel.png"
+            imageAlt="Soft pretzel with salt"
             description="Feeds the whole crowd with ease."
             price="$45"
           />

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -1,21 +1,7 @@
 import ProductCard from "@/components/ProductCard";
+import products from "@/lib/products";
 
 export default function Shop() {
-  const products = [
-    {
-      title: "Box Lunch",
-      image: "/images/bologna.png",
-      description: "Perfect individual meals for any gathering.",
-      price: "$12",
-    },
-    {
-      title: "Party Tray",
-      image: "/images/hot-dog.png",
-      description: "Feeds the whole crowd with ease.",
-      price: "$45",
-    },
-  ];
-
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4">
       <h1 className="text-3xl font-bold text-[#FF0000]">Shop</h1>

--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -1,10 +1,22 @@
 import Image from "next/image";
 import Link from "next/link";
 
-export default function ProductCard({ title, image, description, price }) {
+export default function ProductCard({
+  title,
+  imageSrc,
+  imageAlt,
+  description,
+  price,
+}) {
   return (
     <div className="rounded border p-4 text-center">
-      <Image src={image} alt={title} width={400} height={300} className="mx-auto" />
+      <Image
+        src={imageSrc}
+        alt={imageAlt}
+        width={400}
+        height={300}
+        className="mx-auto"
+      />
       <h3 className="mt-2 text-xl font-bold">{title}</h3>
       <p className="mt-1">{description}</p>
       <p className="mt-1 font-semibold">{price}</p>

--- a/lib/products.js
+++ b/lib/products.js
@@ -1,0 +1,18 @@
+export const products = [
+  {
+    title: "Box Lunch",
+    imageSrc: "/images/hot-dog.png",
+    imageAlt: "Hot dog on a bun",
+    description: "Perfect individual meals for any gathering.",
+    price: "$12",
+  },
+  {
+    title: "Party Tray",
+    imageSrc: "/images/pretzel.png",
+    imageAlt: "Soft pretzel with salt",
+    description: "Feeds the whole crowd with ease.",
+    price: "$45",
+  },
+];
+
+export default products;


### PR DESCRIPTION
## Summary
- move shop product data to `lib/products.js`
- switch product images to existing `.png` files with descriptive alt text
- update `ProductCard` to accept `imageSrc`/`imageAlt`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ed1469108327b0cfc75bb294906b