### PR TITLE
Refactor shop section with reusable product card and standardized data

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import ProductCard from "@/components/ProductCard";
+import ShopSection from "@/components/ShopSection";
 
 export default function Home() {
   return (
@@ -79,26 +79,7 @@ export default function Home() {
         <p className="mt-2">Customer reviews coming soon.</p>
       </section>
 
-      <section className="mx-auto max-w-5xl px-4">
-        <h2 className="text-2xl font-bold text-[#FF0000]">Shop</h2>
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
-          <ProductCard
-            title="Box Lunch"
-            image="/images/tenderloin.png"
-            description="Perfect individual meals for any gathering."
-            price="$12"
-          />
-          <ProductCard
-            title="Party Tray"
-            image="/images/pretzel.png"
-            description="Feeds the whole crowd with ease."
-            price="$45"
-          />
-        </div>
-        <Link href="/shop" className="mt-4 inline-block font-bold text-[#FF0000]">
-          View All →
-        </Link>
-      </section>
+      <ShopSection />
 
       <section className="bg-[#FF0000] py-8 text-center text-white">
         <h2 className="text-2xl font-bold">Ready to work with us?</h2>

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -1,28 +1,16 @@
 import ProductCard from "@/components/ProductCard";
+import { products } from "@/lib/products";
 
 export default function Shop() {
-  const products = [
-    {
-      title: "Box Lunch",
-      image: "/images/bologna.png",
-      description: "Perfect individual meals for any gathering.",
-      price: "$12",
-    },
-    {
-      title: "Party Tray",
-      image: "/images/hot-dog.png",
-      description: "Feeds the whole crowd with ease.",
-      price: "$45",
-    },
-  ];
-
   return (
-    <div className="mx-auto max-w-5xl space-y-6 p-4">
-      <h1 className="text-3xl font-bold text-[#FF0000]">Shop</h1>
-      <div className="grid gap-4 md:grid-cols-2">
-        {products.map((p) => (
-          <ProductCard key={p.title} {...p} />
-        ))}
+    <div className="bg-gradient-to-b from-white to-gray-50/40 py-10 sm:py-12">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <h1 className="text-3xl font-bold text-red-600">Shop</h1>
+        <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {products.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -1,19 +1,38 @@
+"use client";
 import Image from "next/image";
 import Link from "next/link";
 
-export default function ProductCard({ title, image, description, price }) {
+export default function ProductCard({ product }) {
+  const { title, description, price, imageSrc, imageAlt = "", href = "/contact" } = product;
+
   return (
-    <div className="rounded border p-4 text-center">
-      <Image src={image} alt={title} width={400} height={300} className="mx-auto" />
-      <h3 className="mt-2 text-xl font-bold">{title}</h3>
-      <p className="mt-1">{description}</p>
-      <p className="mt-1 font-semibold">{price}</p>
-      <Link
-        href={`/contact?product=${encodeURIComponent(title)}`}
-        className="mt-2 inline-block rounded bg-[#FF0000] px-4 py-2 font-bold text-white hover:bg-[#cc0000]"
-      >
-        Order Inquiry
-      </Link>
-    </div>
+    <article className="group bg-white/95 backdrop-blur rounded-2xl shadow-md ring-1 ring-black/10 hover:shadow-lg transition-shadow overflow-hidden">
+      <div className="relative w-full aspect-[4/3]">
+        <Image
+          src={imageSrc}
+          alt={imageAlt || title}
+          fill
+          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+          className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+          priority={false}
+        />
+      </div>
+
+      <div className="p-5">
+        <h3 className="text-xl font-semibold tracking-tight">{title}</h3>
+        <p className="mt-1 text-sm text-gray-600">{description}</p>
+        <p className="mt-2 text-lg font-bold text-red-600">{price}</p>
+
+        <div className="mt-4">
+          <Link
+            href={href}
+            aria-label={`Order inquiry for ${title}`}
+            className="inline-flex items-center justify-center rounded-xl px-4 py-2 font-medium bg-red-500 text-white hover:bg-red-600 active:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500 transition"
+          >
+            Order Inquiry
+          </Link>
+        </div>
+      </div>
+    </article>
   );
 }

--- a/components/ShopSection.jsx
+++ b/components/ShopSection.jsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import ProductCard from "@/components/ProductCard";
+import { products } from "@/lib/products";
+
+export default function ShopSection() {
+  return (
+    <div className="bg-gradient-to-b from-white to-gray-50/40 py-10 sm:py-12">
+      <section aria-labelledby="shop-heading" className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h2 id="shop-heading" className="text-2xl sm:text-3xl font-extrabold text-red-600">Shop</h2>
+          <Link href="/shop" className="text-sm font-medium hover:underline">View All →</Link>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {products.slice(0, 3).map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lib/products.js
+++ b/lib/products.js
@@ -1,0 +1,20 @@
+export const products = [
+  {
+    id: "box-lunch",
+    title: "Box Lunch",
+    description: "Perfect individual meals for any gathering.",
+    price: "$12",
+    imageSrc: "/images/shop/box-lunch.jpg",
+    imageAlt: "Box lunch on a plate",
+    href: "/contact?item=box-lunch"
+  },
+  {
+    id: "party-tray",
+    title: "Party Tray",
+    description: "Feeds the whole crowd with ease.",
+    price: "$45",
+    imageSrc: "/images/shop/party-tray.jpg",
+    imageAlt: "Pretzel party tray with dipping sauce",
+    href: "/contact?item=party-tray"
+  }
+];


### PR DESCRIPTION
## Summary
- add reusable, accessible `ProductCard` component
- centralize product info in `lib/products.js`
- extract `ShopSection` and update home and shop pages to use it
- remove placeholder box lunch and party tray images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ea2cb63883279bee3bf1aa48fee4