### PR TITLE
Use square aspect ratio for product images on mobile

### DIFF
--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -7,7 +7,7 @@ export default function ProductCard({ product }) {
 
   return (
     <article className="group bg-white/95 backdrop-blur rounded-2xl shadow-md ring-1 ring-black/10 hover:shadow-lg transition-shadow overflow-hidden">
-      <div className="relative w-full aspect-[4/3]">
+      <div className="relative w-full aspect-square md:aspect-[4/3]">
         <Image
           src={imageSrc}
           alt={imageAlt || title}


### PR DESCRIPTION
## Summary
- ensure product images use a square aspect ratio on small screens for better mobile layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f89a02f88327bb5405eeeb1dce5b