### PR TITLE
Add hero component and fix mobile overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,3 +8,7 @@ body {
   background-attachment: fixed;
   background-position: center;
 }
+
+html, body { overflow-x: hidden; }
+img, video { max-width: 100%; height: auto; }
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,39 +1,11 @@
-import Image from "next/image";
 import Link from "next/link";
 import ShopSection from "@/components/ShopSection";
+import Hero from "@/components/Hero";
 
 export default function Home() {
   return (
     <div className="space-y-16">
-      <section className="text-center">
-        <div className="relative mx-auto h-100 max-w-5xl">
-          <Image
-            src="/images/trailer.png"
-            alt="Food trailer"
-            fill
-            className="object-cover"
-          />
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 text-white">
-            <h1 className="text-3xl font-bold">
-              Professional Food Service, Catering & ServSafe Training in Ohio
-            </h1>
-            <div className="mt-4 space-x-4">
-              <Link
-                href="/contact"
-                className="rounded bg-[#FFD700] px-4 py-2 font-bold text-[#FF0000]"
-              >
-                Book a Service
-              </Link>
-              <Link
-                href="/classes"
-                className="rounded bg-[#FF0000] px-4 py-2 font-bold text-white"
-              >
-                Sign Up for a Class
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
+      <Hero />
 
       <section className="mx-auto max-w-5xl px-4">
         <h2 className="text-2xl font-bold text-[#FF0000]">About Us</h2>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,40 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function Hero() {
+  return (
+    <section className="relative h-[56vh] md:h-[70vh]">
+      <Image
+        src="/images/hero-trailer.jpg"
+        alt="Lee's Concessions food trailer"
+        fill
+        className="object-cover"
+        priority
+        sizes="100vw"
+      />
+      <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/30" />
+      <div className="relative z-10 max-w-6xl mx-auto px-4 h-full flex flex-col justify-center text-white">
+        <h1 className="text-4xl md:text-5xl font-bold leading-tight">
+          Food Trailer, Catering & ServSafe® Classes
+        </h1>
+        <p className="mt-3 text-lg opacity-90">
+          Ohio provider. Book services or enroll in the next class.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link
+            href="/classes"
+            className="px-6 py-3 rounded-2xl bg-[#D32F2F] hover:bg-red-700 font-semibold focus:outline-none focus:ring-4 focus:ring-white/40"
+          >
+            Sign Up for a Class
+          </Link>
+          <Link
+            href="/services#catering"
+            className="px-6 py-3 rounded-2xl ring-2 ring-[#FFC107] bg-yellow-400/10 hover:bg-yellow-400/20 font-semibold focus:outline-none focus:ring-4 focus:ring-yellow-200/50"
+          >
+            Book Catering
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- prevent horizontal scroll and ensure images and videos scale with viewport
- add server Hero component with gradient overlay and Next.js Link CTAs
- render Hero at top of home page ahead of existing sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run build` *(fails: Failed to fetch `Inter` font from Google)*

------
https://chatgpt.com/codex/tasks/task_e_689a49d4dd488327971cd579917a5eef